### PR TITLE
nodemon into dependencies for nodemon err in docker-compose

### DIFF
--- a/action/package.json
+++ b/action/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node index.js",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "development": "nodemon server.js"
+    "development": "node_modules/.bin/nodemon server.js",
+    "production": "node server.js"
   },
   "repository": {
     "type": "git",
@@ -23,9 +24,7 @@
     "dotenv": "^10.0.0",
     "mqtt": "^4.2.6",
     "node-cron": "^3.0.0",
-    "pino": "^6.11.1"
-  },
-  "devDependencies": {
+    "pino": "^6.11.1",
     "nodemon": "^2.0.12"
   }
 }


### PR DESCRIPTION
added nodemon to dependencies and removing "devdependencies".

I believe these were the steps taken to troubleshoot issue 13 from deployment configs -- https://github.com/Pyrrha-Platform/Pyrrha-Deployment-Configurations/issues/13
