### PR TITLE
build - fix npm err with /.npm, use node:16-alpine and development env in Dockerfile

### DIFF
--- a/action/Dockerfile
+++ b/action/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/node:12-alpine
+FROM docker.io/node:16-alpine
 
 WORKDIR /user-app
 
@@ -8,6 +8,8 @@ RUN npm ci --only=production
 
 COPY --chown=1001:0 . .
 RUN chmod -R g=u .
+RUN mkdir /.npm
+RUN chown -R 1001:0 /.npm
 
 ARG ENV=production
 ENV NODE_ENV $ENV

--- a/action/Dockerfile.dev
+++ b/action/Dockerfile.dev
@@ -1,4 +1,3 @@
-#FROM docker.io/node:12-alpine
 FROM node:16-alpine
 
 WORKDIR /user-app
@@ -9,6 +8,8 @@ RUN npm ci
 
 COPY --chown=1001:0 . .
 RUN chmod -R g=u .
+RUN mkdir /.npm
+RUN chown -R 1001:0 /.npm
 
 ARG ENV=production
 ENV NODE_ENV $ENV


### PR DESCRIPTION
**Describe at a high level the solution you're providing**

```
pyrrha-simulator        | npm ERR! code EACCES
pyrrha-simulator        | npm ERR! syscall mkdir
pyrrha-simulator        | npm ERR! path /.npm
pyrrha-simulator        | npm ERR! errno -13
pyrrha-simulator        | npm ERR! 
pyrrha-simulator        | npm ERR! Your cache folder contains root-owned files, due to a bug in
pyrrha-simulator        | npm ERR! previous versions of npm which has since been addressed.
pyrrha-simulator        | npm ERR! 
pyrrha-simulator        | npm ERR! To permanently fix this problem, please run:
pyrrha-simulator        | npm ERR!   sudo chown -R 1001:0 "/.npm"
pyrrha-simulator        | 
pyrrha-simulator        | npm ERR! Log files were not written due to an error writing to the directory: /.npm/_logs
pyrrha-simulator        | npm ERR! You can rerun the command with `--loglevel=verbose` to see the logs in your terminal
```
Adding these two commands in the Dockerfiles fixed the above issue: 
```
RUN mkdir /.npm
RUN chown -R 1001:0 /.npm
```

Also, specified the use of node:16-alpine for the Dockerfile, as node:12-alpine is end of life. 
 
**Is this a patch, a minor version change, or a major version change**
Patch

**Is this related to an open issue?**
No

**Additional context**
None